### PR TITLE
Change bash to sh

### DIFF
--- a/redshift.sh
+++ b/redshift.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 checkIfRunning() {


### PR DESCRIPTION
This program cannot run using sh. An easy fix is automatically running the script in bash. (allows for `./redshift.sh` instead of `bash ./redshift.sh`)